### PR TITLE
Fix cibuildwheel repair process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
       APPVEYOR_JOB_NAME: "linux-x64"
+      CIBW_BEFORE_BUILD: "yum install -y omniORB"
 
     - PYTHON: "Python39"
       BUILD_ARCH: "x86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,3 @@ build-dir = "build/{wheel_tag}_{build_type}"
 # Produce only CPython x86_64 wheels
 build = "cp*-manylinux_x86_64"
 
-[tool.cibuildwheel.linux]
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libomniORB4.so.2 --exclude libomnithread.so.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ build-dir = "build/{wheel_tag}_{build_type}"
 # Produce only CPython x86_64 wheels
 build = "cp*-manylinux_x86_64"
 
-[tool.cibuildwheel.linux]
-repair-wheel-command = ""
+#[tool.cibuildwheel.linux]
+#repair-wheel-command = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ build-dir = "build/{wheel_tag}_{build_type}"
 # Produce only CPython x86_64 wheels
 build = "cp*-manylinux_x86_64"
 
-#[tool.cibuildwheel.linux]
-#repair-wheel-command = ""
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libomniORB4.so.2 --exclude libomnithread.so.4"


### PR DESCRIPTION
Hello,

I fixed the auditwheel repair command by excluding 2 sofiles.
Hopefully this will allow to publish the wheels to pypi.

Best regards,